### PR TITLE
Cleanup and review

### DIFF
--- a/clients/gtest/getrf_large_gtest.cpp
+++ b/clients/gtest/getrf_large_gtest.cpp
@@ -1,10 +1,10 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2023 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
-#include "testing_getrf_large.hpp"
 #include "testing_getf2_getrf_npvt.hpp"
+#include "testing_getrf_large.hpp"
 
 using ::testing::Combine;
 using ::testing::TestWithParam;
@@ -12,29 +12,19 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 using namespace std;
 
-// Passing ({n,lda,ldb},nrhs)
 typedef std::tuple<vector<int>, int> getrf_large_tuple;
 
 // each matrix_size_range vector is a {N, lda, ldb}
-// if singular = 1, then the used matrix for the tests is singular
-
 
 // for weekly_lapack tests
-// Since we are going to only be passing square matrix for MATRIX A
-// Matrix B and X will be getting their rows from the the column of X
 const vector<vector<int>> very_large_matrixA_size_range = {
     {25000, 25000, 25000},
 };
 
-// Since this will be the column for both Matrix B and X.
-const vector<int> very_large_nrhs = {
-    300
-};
+const vector<int> very_large_nrhs = {300};
 
-
-// Only passing dimensions for Matrix A and B
 Arguments getrf_large_setup_arguments(getrf_large_tuple tup)
-{   
+{
     vector<int> matrix_sizeA = std::get<0>(tup);
     int nrhs = std::get<1>(tup);
 
@@ -62,14 +52,7 @@ protected:
     {
         Arguments arg = getrf_large_setup_arguments(GetParam());
 
-        // if(arg.peek<rocblas_int>("m") == 0 && arg.peek<rocblas_int>("n") == 0)
-        //     testing_getrf_large_bad_arg<BATCHED, STRIDED, true, T>();
-
         arg.batch_count = (BATCHED || STRIDED ? 3 : 1);
-        if(arg.singular == 1)
-            testing_getrf_large<BATCHED, STRIDED, true, T>(arg);
-
-        arg.singular = 0;
         testing_getrf_large<BATCHED, STRIDED, true, T>(arg);
     }
 };
@@ -88,46 +71,12 @@ protected:
     {
         Arguments arg = getrf_large_setup_arguments(GetParam());
 
-        if(arg.peek<rocblas_int>("m") == 0 && arg.peek<rocblas_int>("n") == 0)
-            testing_getf2_getrf_npvt_bad_arg<BATCHED, STRIDED, true, T>();
-
         arg.batch_count = (BATCHED || STRIDED ? 3 : 1);
-        if(arg.singular == 1)
-            testing_getf2_getrf_npvt<BATCHED, STRIDED, true, T>(arg);
-
-        arg.singular = 0;
         testing_getf2_getrf_npvt<BATCHED, STRIDED, true, T>(arg);
     }
 };
 
-// class GETRF_LARGE : public GETF2_GETRF<true>
-// {
-// };
-
-// class GETRF_LARGE_NPVT : public GETF2_GETRF_NPVT<true>
-// {
-// };
-
-// // non-batch tests
-// TEST_P(GETRF_NPVT, __float)
-// {
-//     run_tests<false, false, float>();
-// }
-
-// TEST_P(GETRF_NPVT, __double)
-// {
-//     run_tests<false, false, double>();
-// }
-
-// TEST_P(GETRF_NPVT, __float_complex)
-// {
-//     run_tests<false, false, rocblas_float_complex>();
-// }
-
-// TEST_P(GETRF_NPVT, __double_complex)
-// {
-//     run_tests<false, false, rocblas_double_complex>();
-// }
+// non-batch tests
 
 TEST_P(GETRF_LARGE, __float)
 {
@@ -151,26 +100,6 @@ TEST_P(GETRF_LARGE, __double_complex)
 
 // batched tests
 
-// TEST_P(GETRF_NPVT, batched__float)
-// {
-//     run_tests<true, true, float>();
-// }
-
-// TEST_P(GETRF_NPVT, batched__double)
-// {
-//     run_tests<true, true, double>();
-// }
-
-// TEST_P(GETRF_NPVT, batched__float_complex)
-// {
-//     run_tests<true, true, rocblas_float_complex>();
-// }
-
-// TEST_P(GETRF_NPVT, batched__double_complex)
-// {
-//     run_tests<true, true, rocblas_double_complex>();
-// }
-
 TEST_P(GETRF_LARGE, batched__float)
 {
     run_tests<true, true, float>();
@@ -191,26 +120,7 @@ TEST_P(GETRF_LARGE, batched__double_complex)
     run_tests<true, true, rocblas_double_complex>();
 }
 
-// TEST_P(GETRF_NPVT, strided_batched__float)
-// {
-//     run_tests<false, true, float>();
-// }
-
-// TEST_P(GETRF_NPVT, strided_batched__double)
-// {
-//     run_tests<false, true, double>();
-// }
-
-// TEST_P(GETRF_NPVT, strided_batched__float_complex)
-// {
-//     run_tests<false, true, rocblas_float_complex>();
-// }
-
-// TEST_P(GETRF_NPVT, strided_batched__double_complex)
-// {
-//     run_tests<false, true, rocblas_double_complex>();
-// }
-
+// strided_batched tests
 
 TEST_P(GETRF_LARGE, strided_batched__float)
 {
@@ -232,8 +142,6 @@ TEST_P(GETRF_LARGE, strided_batched__double_complex)
     run_tests<false, true, rocblas_double_complex>();
 }
 
-
 INSTANTIATE_TEST_SUITE_P(weekly_lapack,
                          GETRF_LARGE,
-                         Combine(ValuesIn(very_large_matrixA_size_range),ValuesIn(very_large_nrhs)));
-
+                         Combine(ValuesIn(very_large_matrixA_size_range), ValuesIn(very_large_nrhs)));

--- a/clients/include/testing_getrf_large.hpp
+++ b/clients/include/testing_getrf_large.hpp
@@ -12,119 +12,23 @@
 #include "rocsolver_arguments.hpp"
 #include "rocsolver_test.hpp"
 
-// I dont think we need to check for bad arguments, do we ?
-template <bool STRIDED, bool GETRF, typename T, typename U>
-void getrf_large_checkBadArgs(const rocblas_handle handle,
-                              const rocblas_int m,
-                              const rocblas_int n,
-                              T dA,
-                              const rocblas_int lda,
-                              const rocblas_stride stA,
-                              U dIpiv,
-                              const rocblas_stride stP,
-                              U dinfo,
-                              const rocblas_int bc)
-{
-    // handle
-    EXPECT_ROCBLAS_STATUS(
-        rocsolver_getf2_getrf(STRIDED, GETRF, nullptr, m, n, dA, lda, stA, dIpiv, stP, dinfo, bc),
-        rocblas_status_invalid_handle);
-
-    // values
-    // N/A
-
-    // sizes (only check batch_count if applicable)
-    if(STRIDED)
-        EXPECT_ROCBLAS_STATUS(rocsolver_getf2_getrf(STRIDED, GETRF, handle, m, n, dA, lda, stA,
-                                                    dIpiv, stP, dinfo, -1),
-                              rocblas_status_invalid_size);
-
-    // pointers
-    EXPECT_ROCBLAS_STATUS(rocsolver_getf2_getrf(STRIDED, GETRF, handle, m, n, (T) nullptr, lda, stA,
-                                                dIpiv, stP, dinfo, bc),
-                          rocblas_status_invalid_pointer);
-    EXPECT_ROCBLAS_STATUS(rocsolver_getf2_getrf(STRIDED, GETRF, handle, m, n, dA, lda, stA,
-                                                (U) nullptr, stP, dinfo, bc),
-                          rocblas_status_invalid_pointer);
-    EXPECT_ROCBLAS_STATUS(rocsolver_getf2_getrf(STRIDED, GETRF, handle, m, n, dA, lda, stA, dIpiv,
-                                                stP, (U) nullptr, bc),
-                          rocblas_status_invalid_pointer);
-
-    // quick return with invalid pointers
-    EXPECT_ROCBLAS_STATUS(rocsolver_getf2_getrf(STRIDED, GETRF, handle, 0, n, (T) nullptr, lda, stA,
-                                                (U) nullptr, stP, dinfo, bc),
-                          rocblas_status_success);
-    EXPECT_ROCBLAS_STATUS(rocsolver_getf2_getrf(STRIDED, GETRF, handle, m, 0, (T) nullptr, lda, stA,
-                                                (U) nullptr, stP, dinfo, bc),
-                          rocblas_status_success);
-    if(STRIDED)
-        EXPECT_ROCBLAS_STATUS(rocsolver_getf2_getrf(STRIDED, GETRF, handle, m, n, dA, lda, stA,
-                                                    dIpiv, stP, (U) nullptr, 0),
-                              rocblas_status_success);
-
-    // quick return with zero batch_count if applicable
-    if(STRIDED)
-        EXPECT_ROCBLAS_STATUS(
-            rocsolver_getf2_getrf(STRIDED, GETRF, handle, m, n, dA, lda, stA, dIpiv, stP, dinfo, 0),
-            rocblas_status_success);
-}
-
-template <bool BATCHED, bool STRIDED, bool GETRF, typename T>
-void testing_getrf_large_bad_arg()
-{
-    // safe arguments
-    rocblas_local_handle handle;
-    rocblas_int m = 1;
-    rocblas_int n = 1;
-    rocblas_int lda = 1;
-    rocblas_stride stA = 1;
-    rocblas_stride stP = 1;
-    rocblas_int bc = 1;
-
-    if(BATCHED)
-    {
-        // memory allocations
-        device_batch_vector<T> dA(1, 1, 1);
-        device_strided_batch_vector<rocblas_int> dIpiv(1, 1, 1, 1);
-        device_strided_batch_vector<rocblas_int> dInfo(1, 1, 1, 1);
-        CHECK_HIP_ERROR(dA.memcheck());
-        CHECK_HIP_ERROR(dIpiv.memcheck());
-        CHECK_HIP_ERROR(dInfo.memcheck());
-
-        // check bad arguments
-        getrf_large_checkBadArgs<STRIDED, GETRF>(handle, m, n, dA.data(), lda, stA, dIpiv.data(),
-                                                 stP, dInfo.data(), bc);
-    }
-    else
-    {
-        // memory allocations
-        device_strided_batch_vector<T> dA(1, 1, 1, 1);
-        device_strided_batch_vector<rocblas_int> dIpiv(1, 1, 1, 1);
-        device_strided_batch_vector<rocblas_int> dInfo(1, 1, 1, 1);
-        CHECK_HIP_ERROR(dA.memcheck());
-        CHECK_HIP_ERROR(dIpiv.memcheck());
-        CHECK_HIP_ERROR(dInfo.memcheck());
-
-        // check bad arguments
-        getrf_large_checkBadArgs<STRIDED, GETRF>(handle, m, n, dA.data(), lda, stA, dIpiv.data(),
-                                                 stP, dInfo.data(), bc);
-    }
-}
-
-
-// This is our initialization function, we have to modify it in order to initialize multiple Matrices at once.
 template <bool CPU, bool GPU, typename T, typename Td, typename Ud, typename Th, typename Uh>
 void getrf_large_initData(const rocblas_handle handle,
-                          const rocblas_int m,
                           const rocblas_int n,
+                          const rocblas_int nrhs,
                           Td& dA,
                           const rocblas_int lda,
                           const rocblas_stride stA,
+                          Td& dB,
+                          const rocblas_int ldb,
+                          const rocblas_stride stB,
+                          Td& dX,
                           Ud& dIpiv,
                           const rocblas_stride stP,
                           Ud& dInfo,
                           const rocblas_int bc,
                           Th& hA,
+                          Th& hB,
                           Uh& hIpiv,
                           Uh& hInfo,
                           const bool singular)
@@ -133,11 +37,12 @@ void getrf_large_initData(const rocblas_handle handle,
     {
         T tmp;
         rocblas_init<T>(hA, true);
+        rocblas_init<T>(hB, false);
 
         for(rocblas_int b = 0; b < bc; ++b)
         {
             // scale A to avoid singularities
-            for(rocblas_int i = 0; i < m; i++)
+            for(rocblas_int i = 0; i < n; i++)
             {
                 for(rocblas_int j = 0; j < n; j++)
                 {
@@ -150,13 +55,13 @@ void getrf_large_initData(const rocblas_handle handle,
 
             // shuffle rows to test pivoting
             // always the same permuation for debugging purposes
-            for(rocblas_int i = 0; i < m / 2; i++)
+            for(rocblas_int i = 0; i < n / 2; i++)
             {
                 for(rocblas_int j = 0; j < n; j++)
                 {
                     tmp = hA[b][i + j * lda];
-                    hA[b][i + j * lda] = hA[b][m - 1 - i + j * lda];
-                    hA[b][m - 1 - i + j * lda] = tmp;
+                    hA[b][i + j * lda] = hA[b][n - 1 - i + j * lda];
+                    hA[b][n - 1 - i + j * lda] = tmp;
                 }
             }
 
@@ -168,15 +73,15 @@ void getrf_large_initData(const rocblas_handle handle,
                 // matrices in the batch that are singular
                 rocblas_int j = n / 4 + b;
                 j -= (j / n) * n;
-                for(rocblas_int i = 0; i < m; i++)
+                for(rocblas_int i = 0; i < n; i++)
                     hA[b][i + j * lda] = 0;
                 j = n / 2 + b;
                 j -= (j / n) * n;
-                for(rocblas_int i = 0; i < m; i++)
+                for(rocblas_int i = 0; i < n; i++)
                     hA[b][i + j * lda] = 0;
                 j = n - 1 + b;
                 j -= (j / n) * n;
-                for(rocblas_int i = 0; i < m; i++)
+                for(rocblas_int i = 0; i < n; i++)
                     hA[b][i + j * lda] = 0;
             }
         }
@@ -186,6 +91,8 @@ void getrf_large_initData(const rocblas_handle handle,
     {
         // now copy data to the GPU
         CHECK_HIP_ERROR(dA.transfer_from(hA));
+        CHECK_HIP_ERROR(dB.transfer_from(hB));
+        CHECK_HIP_ERROR(dX.transfer_from(hB));
     }
 }
 
@@ -194,82 +101,50 @@ void getrf_large_getError(const rocblas_handle handle,
                           const rocblas_int n,
                           const rocblas_int nrhs,
                           Td& dA,
-                          Td& dB,
-                          Td& dX,
                           const rocblas_int lda,
-                          const rocblas_int ldb,
-                          const rocblas_int ldx,
                           const rocblas_stride stA,
+                          Td& dB,
+                          const rocblas_int ldb,
                           const rocblas_stride stB,
-                          const rocblas_stride stX,
+                          Td& dX,
                           Ud& dIpiv,
                           const rocblas_stride stP,
                           Ud& dInfo,
                           const rocblas_int bc,
                           Th& hA,
                           Th& hB,
-                          Th& hX,
-                          Th& hARes,
                           Th& hBRes,
-                          Th& hXRes,
-                          size_t size_A,
-                          size_t size_B,
-                          size_t size_X,
                           Uh& hIpiv,
-                          Uh& hIpivRes,
                           Uh& hInfo,
                           Uh& hInfoRes,
                           double* max_err,
                           const bool singular)
-{   
-
-    // Modify the init data method itself to initialize both A and B together.
+{
     // Input data initialization for Matrix A
-    getrf_large_initData<true, true, T>(handle, n, n, dA, lda, stA, dIpiv, stP, dInfo, bc, hA,
-                                        hIpiv, hInfo, singular);
-    
-    // Input data initialization for Matrix B
-    getrf_large_initData<true, true, T>(handle, n, nrhs, dB, ldb, stB, dIpiv, stP, dInfo, bc, hB,
-                                        hIpiv, hInfo, singular);
-    
-
-    //copy from host to device memory for matrice X
-    CHECK_HIP_ERROR(dX.transfer_from(hB));  
-
+    getrf_large_initData<true, true, T>(handle, n, nrhs, dA, lda, stA, dB, ldb, stB, dX, dIpiv, stP,
+                                        dInfo, bc, hA, hB, hIpiv, hInfo, singular);
 
     // execute computations
     // GPU lapack
     CHECK_ROCBLAS_ERROR(rocsolver_getf2_getrf(STRIDED, GETRF, handle, n, n, dA.data(), lda, stA,
                                               dIpiv.data(), stP, dInfo.data(), bc));
-    // CHECK_HIP_ERROR(hARes.transfer_from(dA));
-    // CHECK_HIP_ERROR(hIpivRes.transfer_from(dIpiv));
-    // CHECK_HIP_ERROR(hInfoRes.transfer_from(dInfo));
 
-    // Calling the GETRS function with modififed value of dA and result of the operation will be stored in dA.
-    // Perhaps it would be better to use CHECK_ROCBLAS_ERROR()
-    auto re = rocsolver_getrs(STRIDED,handle, rocblas_operation_none,
-                        n, nrhs, dA, lda, stA, dIpiv, stP, dX, ldx, stX, bc);
-    if (re != rocblas_status_success)
-        std::cout << "getrs failed" << std::endl;
-    
+    CHECK_ROCBLAS_ERROR(rocsolver_getrs(STRIDED, handle, rocblas_operation_none, n, nrhs, dA, lda,
+                                        stA, dIpiv, stP, dX, ldb, stB, bc));
+
     // Resetting the value of dA.
     CHECK_HIP_ERROR(dA.transfer_from(hA));
 
-    // Calling the GEMM function
-    T alpha = 1., beta = 0.;
-    auto he = rocblas_gemm(STRIDED, handle, rocblas_operation_none, rocblas_operation_none,
-                          n, nrhs, n, &alpha, dA, lda, stA, dX, ldx, stX, &beta, dB, ldb, stB, bc);
-    if (he != rocblas_status_success) //HIPBLAS_STATUS_SUCCESS)
-    std::cout << "gemm failed" << std::endl;
-
-    // Copying the result of the dgemm operation to the host memory
+    T alpha = T(1), beta = T(0);
+    CHECK_ROCBLAS_ERROR(rocblas_gemm(STRIDED, handle, rocblas_operation_none,
+                                     rocblas_operation_none, n, nrhs, n, &alpha, dA, lda, stA, dX,
+                                     ldb, stB, &beta, dB, ldb, stB, bc));
     CHECK_HIP_ERROR(hBRes.transfer_from(dB));
-    
-    // Checking for errors.
+
     double err;
     *max_err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
-    {   // Pass the matrices here
+    { // Pass the matrices here
         err = norm_error('F', n, nrhs, ldb, hB[b], hBRes[b]);
         *max_err = err > *max_err ? err : *max_err;
     }
@@ -298,61 +173,54 @@ void getrf_large_getPerfData(const rocblas_handle handle,
                              const bool perf,
                              const bool singular)
 {
-    return;
+    *cpu_time_used = nan(""); // no timing on cpu-lapack execution
+    *gpu_time_used = nan(""); // no timing on gpu-lapack execution
 }
-
 
 template <bool BATCHED, bool STRIDED, bool GETRF, typename T>
 void testing_getrf_large(Arguments& argus)
-{   
+{
     // get arguments
     rocblas_local_handle handle;
     rocblas_int n = argus.get<rocblas_int>("n");
-    rocblas_int nrhs = argus.get<rocblas_int>("nrhs",n);
+    rocblas_int nrhs = argus.get<rocblas_int>("nrhs", n);
     rocblas_int lda = argus.get<rocblas_int>("lda", n);
     rocblas_int ldb = argus.get<rocblas_int>("ldb", n);
-    rocblas_int ldx = ldb;
     rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
     rocblas_stride stB = argus.get<rocblas_stride>("strideB", ldb * nrhs);
-    rocblas_stride stX = argus.get<rocblas_stride>("strideX", ldx * nrhs);
-    rocblas_stride stP = argus.get<rocblas_stride>("strideP",n);
+    rocblas_stride stP = argus.get<rocblas_stride>("strideP", n);
 
     rocblas_int bc = argus.batch_count;
     rocblas_int hot_calls = argus.iters;
 
     rocblas_stride stARes = (argus.unit_check || argus.norm_check) ? stA : 0;
     rocblas_stride stBRes = (argus.unit_check || argus.norm_check) ? stB : 0;
-    rocblas_stride stXRes = (argus.unit_check || argus.norm_check) ? stX : 0;
     rocblas_stride stPRes = (argus.unit_check || argus.norm_check) ? stP : 0;
 
     // determine sizes using the leading Dimensions, which are typically greater than the rows
     size_t size_A = size_t(lda) * n;
     size_t size_B = size_t(ldb) * nrhs;
-    size_t size_X = size_B;
     size_t size_P = size_t(n);
     double max_error = 0, gpu_time_used = 0, cpu_time_used = 0;
 
     size_t size_ARes = (argus.unit_check || argus.norm_check) ? size_A : 0;
     size_t size_BRes = (argus.unit_check || argus.norm_check) ? size_B : 0;
-    size_t size_XRes = (argus.unit_check || argus.norm_check) ? size_X : 0;
     size_t size_PRes = (argus.unit_check || argus.norm_check) ? size_P : 0;
 
     // check invalid sizes
-    bool invalid_size = (n < 0 || nrhs < 0 || lda < n || bc < 0);
+    bool invalid_size = (n < 0 || nrhs < 0 || lda < n || ldb < n || bc < 0);
     if(invalid_size)
     {
-        if(BATCHED)
-            EXPECT_ROCBLAS_STATUS(
-                rocsolver_getf2_getrf(STRIDED, GETRF, handle, n, n, (T* const*)nullptr, lda, stA,
-                                      (rocblas_int*)nullptr, stP, (rocblas_int*)nullptr, bc),
-                rocblas_status_invalid_size);
-        else
-            EXPECT_ROCBLAS_STATUS(rocsolver_getf2_getrf(STRIDED, GETRF, handle, n, n, (T*)nullptr,
-                                                        lda, stA, (rocblas_int*)nullptr, stP,
-                                                        (rocblas_int*)nullptr, bc),
-                                  rocblas_status_invalid_size);
-        
-        
+        // if(BATCHED)
+        //     EXPECT_ROCBLAS_STATUS(
+        //         rocsolver_getf2_getrf(STRIDED, GETRF, handle, n, n, (T* const*)nullptr, lda, stA,
+        //                               (rocblas_int*)nullptr, stP, (rocblas_int*)nullptr, bc),
+        //         rocblas_status_invalid_size);
+        // else
+        //     EXPECT_ROCBLAS_STATUS(rocsolver_getf2_getrf(STRIDED, GETRF, handle, n, n, (T*)nullptr,
+        //                                                 lda, stA, (rocblas_int*)nullptr, stP,
+        //                                                 (rocblas_int*)nullptr, bc),
+        //                           rocblas_status_invalid_size);
 
         if(argus.timing)
             rocsolver_bench_inform(inform_invalid_size);
@@ -389,41 +257,34 @@ void testing_getrf_large(Arguments& argus)
         // memory allocations
         host_batch_vector<T> hA(size_A, 1, bc);
         host_batch_vector<T> hB(size_B, 1, bc);
-        host_batch_vector<T> hX(size_X, 1, bc);
-        host_batch_vector<T> hARes(size_ARes, 1, bc);
         host_batch_vector<T> hBRes(size_BRes, 1, bc);
-        host_batch_vector<T> hXRes(size_XRes, 1, bc);
         host_strided_batch_vector<rocblas_int> hIpiv(size_P, 1, stP, bc);
-        host_strided_batch_vector<rocblas_int> hIpivRes(size_PRes, 1, stPRes, bc);
         host_strided_batch_vector<rocblas_int> hInfo(1, 1, 1, bc);
         host_strided_batch_vector<rocblas_int> hInfoRes(1, 1, 1, bc);
         device_batch_vector<T> dA(size_A, 1, bc);
         device_batch_vector<T> dB(size_B, 1, bc);
-        device_batch_vector<T> dX(size_X, 1, bc);
+        device_batch_vector<T> dX(size_B, 1, bc);
         device_strided_batch_vector<rocblas_int> dIpiv(size_P, 1, stP, bc);
         device_strided_batch_vector<rocblas_int> dInfo(1, 1, 1, bc);
 
         if(size_A)
             CHECK_HIP_ERROR(dA.memcheck());
         if(size_B)
+        {
             CHECK_HIP_ERROR(dB.memcheck());
-        if(size_X)
             CHECK_HIP_ERROR(dX.memcheck());
-
-        CHECK_HIP_ERROR(dInfo.memcheck());
+        }
         if(size_P)
             CHECK_HIP_ERROR(dIpiv.memcheck());
-
+        CHECK_HIP_ERROR(dInfo.memcheck());
 
         // check computations
         if(argus.unit_check || argus.norm_check)
             // Modify the parameters passed.
-            getrf_large_getError<STRIDED, GETRF, T>(handle, n, nrhs, dA, dB, dX, lda, ldb, ldx,
-                                                     stA, stB, stX, dIpiv, stP, dInfo,
-                                                    bc, hA, hB, hX, hARes, hBRes, hXRes, size_A, size_B, size_X, hIpiv, hIpivRes, hInfo, hInfoRes,
-                                                    &max_error, argus.singular);
+            getrf_large_getError<STRIDED, GETRF, T>(handle, n, nrhs, dA, lda, stA, dB, ldb, stB, dX,
+                                                    dIpiv, stP, dInfo, bc, hA, hB, hBRes, hIpiv,
+                                                    hInfo, hInfoRes, &max_error, argus.singular);
 
-        // This should be returning NAN
         // collect performance data
         if(argus.timing)
             getrf_large_getPerfData<STRIDED, GETRF, T>(
@@ -432,44 +293,37 @@ void testing_getrf_large(Arguments& argus)
                 argus.singular);
     }
 
-
-    // These are the allocations for the non batched version
     else
     {
         // memory allocations
         host_strided_batch_vector<T> hA(size_A, 1, stA, bc);
         host_strided_batch_vector<T> hB(size_B, 1, stB, bc);
-        host_strided_batch_vector<T> hX(size_X, 1, stX, bc);
-        host_strided_batch_vector<T> hARes(size_ARes, 1, stARes, bc);
-        host_strided_batch_vector<T> hBRes(size_BRes, 1, stARes, bc);
-        host_strided_batch_vector<T> hXRes(size_XRes, 1, stARes, bc);
+        host_strided_batch_vector<T> hBRes(size_BRes, 1, stBRes, bc);
         host_strided_batch_vector<rocblas_int> hIpiv(size_P, 1, stP, bc);
-        host_strided_batch_vector<rocblas_int> hIpivRes(size_PRes, 1, stPRes, bc);
         host_strided_batch_vector<rocblas_int> hInfo(1, 1, 1, bc);
         host_strided_batch_vector<rocblas_int> hInfoRes(1, 1, 1, bc);
         device_strided_batch_vector<T> dA(size_A, 1, stA, bc);
         device_strided_batch_vector<T> dB(size_B, 1, stB, bc);
-        device_strided_batch_vector<T> dX(size_X, 1, stX, bc);
+        device_strided_batch_vector<T> dX(size_B, 1, stB, bc);
         device_strided_batch_vector<rocblas_int> dIpiv(size_P, 1, stP, bc);
         device_strided_batch_vector<rocblas_int> dInfo(1, 1, 1, bc);
 
         if(size_A)
             CHECK_HIP_ERROR(dA.memcheck());
         if(size_B)
+        {
             CHECK_HIP_ERROR(dB.memcheck());
-        if(size_X)
             CHECK_HIP_ERROR(dX.memcheck());
-        CHECK_HIP_ERROR(dInfo.memcheck());
+        }
         if(size_P)
             CHECK_HIP_ERROR(dIpiv.memcheck());
-
+        CHECK_HIP_ERROR(dInfo.memcheck());
 
         // check computations
         if(argus.unit_check || argus.norm_check)
-            getrf_large_getError<STRIDED, GETRF, T>(handle, n, nrhs, dA, dB, dX, lda, ldb, ldx,
-                                                     stA, stB, stX, dIpiv, stP, dInfo,
-                                                    bc, hA, hB, hX, hARes, hBRes, hXRes, size_A, size_B, size_X, hIpiv, hIpivRes, hInfo, hInfoRes,
-                                                    &max_error, argus.singular);
+            getrf_large_getError<STRIDED, GETRF, T>(handle, n, nrhs, dA, lda, stA, dB, ldb, stB, dX,
+                                                    dIpiv, stP, dInfo, bc, hA, hB, hBRes, hIpiv,
+                                                    hInfo, hInfoRes, &max_error, argus.singular);
 
         // The perf function must return NAN
         // collect performance data
@@ -479,7 +333,6 @@ void testing_getrf_large(Arguments& argus)
                 &cpu_time_used, hot_calls, argus.profile, argus.profile_kernels, argus.perf,
                 argus.singular);
     }
-
 
     // validate results for rocsolver-test
     // using min(m,n) * machine_precision as tolerance
@@ -493,18 +346,19 @@ void testing_getrf_large(Arguments& argus)
             rocsolver_bench_header("Arguments:");
             if(BATCHED)
             {
-                rocsolver_bench_output("m", "n", "lda", "strideP", "batch_c");
-                rocsolver_bench_output(n, n, lda, stP, bc);
+                rocsolver_bench_output("n", "nrhs", "lda", "ldb", "strideP", "batch_c");
+                rocsolver_bench_output(n, nrhs, lda, ldb, stP, bc);
             }
             else if(STRIDED)
             {
-                rocsolver_bench_output("m", "n", "lda", "strideA", "strideP", "batch_c");
-                rocsolver_bench_output(n, n, lda, stA, stP, bc);
+                rocsolver_bench_output("n", "nrhs", "lda", "strideA", "ldb", "strideB", "strideP",
+                                       "batch_c");
+                rocsolver_bench_output(n, nrhs, lda, stA, ldb, stB, stP, bc);
             }
             else
             {
-                rocsolver_bench_output("m", "n", "lda");
-                rocsolver_bench_output(n, n, lda);
+                rocsolver_bench_output("n", "nrhs", "lda", "ldb");
+                rocsolver_bench_output(n, nrhs, lda, ldb);
             }
             rocsolver_bench_header("Results:");
             if(argus.norm_check)


### PR DESCRIPTION
I've taken the liberty of making the changes I would have requested in my review, mainly removing unnecessary comments and arrays. I believe I also found the source of the failure we were experiencing: the declaration of `hBRes` on line 444 used `stARes` instead of `stBRes`.

We might need to comment out some of the test cases and/or reduce the tested matrix size, since my machine was running out of device memory even before reaching the batched cases. There also seem to be some test failures, which are likely not problems with the test but with the library code. We'll need to look into it further.